### PR TITLE
feat: Add password visibility toggle to login/signup forms

### DIFF
--- a/views/users/login.ejs
+++ b/views/users/login.ejs
@@ -16,9 +16,21 @@
            
             <div class="mb-3">
                 <label for="password" class="form-label">password</label>
-                <input type="password" name="password"  class="form-control" id="password" required>
-               
-                
+                <div class="input-group">
+                    <input type="password" name="password" class="form-control" id="password" required>
+                    <button class="btn btn-outline-secondary" type="button" id="togglePassword" title="Toggle password visibility">
+                        <!-- Eye Icon (Show Password) -->
+                        <svg id="eyeIcon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+                            <circle cx="12" cy="12" r="3"></circle>
+                        </svg>
+                        <!-- Eye-off Icon (Hide Password) -->
+                        <svg id="eyeSlashIcon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:none;">
+                            <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path>
+                            <line x1="1" y1="1" x2="23" y2="23"></line>
+                        </svg>
+                    </button>
+                </div>
               </div>
 
 
@@ -30,3 +42,22 @@
 
     </div>
 </div>
+
+<script>
+document.getElementById('togglePassword').addEventListener('click', function(e) {
+    e.preventDefault();
+    const passwordInput = document.getElementById('password');
+    const eyeIcon = document.getElementById('eyeIcon');
+    const eyeSlashIcon = document.getElementById('eyeSlashIcon');
+    
+    if (passwordInput.type === 'password') {
+        passwordInput.type = 'text';
+        eyeIcon.style.display = 'none';
+        eyeSlashIcon.style.display = 'inline';
+    } else {
+        passwordInput.type = 'password';
+        eyeIcon.style.display = 'inline';
+        eyeSlashIcon.style.display = 'none';
+    }
+});
+</script>

--- a/views/users/signup.ejs
+++ b/views/users/signup.ejs
@@ -25,9 +25,21 @@
               </div>
             <div class="mb-3">
                 <label for="password" class="form-label">password</label>
-                <input type="password" name="password"  class="form-control" id="password" required>
-               
-                
+                <div class="input-group">
+                    <input type="password" name="password" class="form-control" id="password" required>
+                    <button class="btn btn-outline-secondary" type="button" id="togglePassword" title="Toggle password visibility">
+                        <!-- Eye Icon (Show Password) -->
+                        <svg id="eyeIcon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+                            <circle cx="12" cy="12" r="3"></circle>
+                        </svg>
+                        <!-- Eye-off Icon (Hide Password) -->
+                        <svg id="eyeSlashIcon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:none;">
+                            <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path>
+                            <line x1="1" y1="1" x2="23" y2="23"></line>
+                        </svg>
+                    </button>
+                </div>
               </div>
 
 
@@ -39,3 +51,22 @@
 
     </div>
 </div>
+
+<script>
+document.getElementById('togglePassword').addEventListener('click', function(e) {
+    e.preventDefault();
+    const passwordInput = document.getElementById('password');
+    const eyeIcon = document.getElementById('eyeIcon');
+    const eyeSlashIcon = document.getElementById('eyeSlashIcon');
+    
+    if (passwordInput.type === 'password') {
+        passwordInput.type = 'text';
+        eyeIcon.style.display = 'none';
+        eyeSlashIcon.style.display = 'inline';
+    } else {
+        passwordInput.type = 'password';
+        eyeIcon.style.display = 'inline';
+        eyeSlashIcon.style.display = 'none';
+    }
+});
+</script>


### PR DESCRIPTION
## Description
Add a show/hide password toggle eye icon to the login and signup forms for improved UX.

## Changes
- Added password visibility toggle button with eye/eye-slash icons
- Uses Bootstrap 5 `input-group` styling
- Inline SVG icons (no external dependencies)
- JavaScript toggle switches between `password` and `text` input types

## Screenshot
**Hidden State (Default):**
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/d9a23640-d232-4515-937d-a52e8b37db34" />

**Visible State:**
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/0b54fe40-01f1-48d0-adad-5d26a6cb546a" />


## Closes #20 