### PR TITLE
Fix: Display total price after taxes toggle switch functionality 

### DIFF
--- a/views/listings/index.ejs
+++ b/views/listings/index.ejs
@@ -115,8 +115,8 @@
 
       <div class="tax-toggle">
         <div class="form-check-reverse form-switch">
-          <input class="form-check-input" type="checkbox" role="switch" id="switchCheckDefault">
-          <label class="form-check-label" for="switchCheckDefault">Display total after taxes</label>
+          <input class="form-check-input" type="checkbox" role="switch" id="flexSwitchCheckDefault">
+          <label class="form-check-label" for="flexSwitchCheckDefault">Display total after taxes</label>
         </div>
       </div>
 


### PR DESCRIPTION
### Description
This Pull Request fixes the "Display total price after taxes" toggle on the main listings page. Previously, the toggle was unresponsive due to an ID mismatch between the HTML input element and the frontend JavaScript event listener.

### Changes Made
- Updated the HTML `id` and `for` attributes of the toggle switch to match the expected ID in the JavaScript logic.
- Ensured the event listener correctly targets the toggle switch by its proper ID.


### Expected Behavior
- When the switch is toggled **ON**, the tax percentage dynamically displays next to the base price on all listings.
- When the switch is toggled **OFF**, the UI hides the tax information and reverts to showing only the standard base price.
- The UI updates instantly without requiring a page reload.

### Issue
Closes #39 
<img width="1854" height="800" alt="image" src="https://github.com/user-attachments/assets/2c16fb5b-b68b-4329-a3fd-441971bdc40a" />
<img width="1835" height="899" alt="image" src="https://github.com/user-attachments/assets/7496f162-7dec-4dc3-b66a-09a359ce9cc7" />


